### PR TITLE
Fixed bug in keepalive option

### DIFF
--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -99,7 +99,7 @@ commands:
                             action='store', dest='url', type='string',
                             help="URL of the target to attack.")
     attack_group.add_option('-K', '--keepalive', metavar="KEEP_ALIVE", nargs=0,
-                            action='store', dest='keep_alive', type='string', default=False,
+                            action='store_true', dest='keep_alive', type='string', default=False,
                             help="Keep-Alive connection.")
     attack_group.add_option('-p', '--post-file',  metavar="POST_FILE",  nargs=1,
                             action='store', dest='post_file', type='string', default=False,

--- a/beeswithmachineguns/main.py
+++ b/beeswithmachineguns/main.py
@@ -98,8 +98,8 @@ commands:
     attack_group.add_option('-u', '--url', metavar="URL", nargs=1,
                             action='store', dest='url', type='string',
                             help="URL of the target to attack.")
-    attack_group.add_option('-K', '--keepalive', metavar="KEEP_ALIVE", nargs=0,
-                            action='store_true', dest='keep_alive', type='string', default=False,
+    attack_group.add_option('-K', '--keepalive', metavar="KEEP_ALIVE",
+                            action='store_true', dest='keep_alive', default=False,
                             help="Keep-Alive connection.")
     attack_group.add_option('-p', '--post-file',  metavar="POST_FILE",  nargs=1,
                             action='store', dest='post_file', type='string', default=False,


### PR DESCRIPTION
Ran a tcpdump and saw that even when I set keepalive to true it was being ignored then found that the store parameter was set incorrectly. All measurements have been wrong if you have used this software and thought you had keepalive enabled!
